### PR TITLE
 Changed all the references affecting register/login from <IdentityUser> to <ApplicationUser>

### DIFF
--- a/3LTB/3LTB/Areas/Identity/Data/_3LTBContext.cs
+++ b/3LTB/3LTB/Areas/Identity/Data/_3LTBContext.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace _3LTB.Data
 {
-    public class _3LTBContext : IdentityDbContext<_3LTBIdentityUser>
+    public class _3LTBContext : IdentityDbContext<ApplicationUser>
     {
         public _3LTBContext(DbContextOptions<_3LTBContext> options)
             : base(options)

--- a/3LTB/3LTB/Areas/Identity/IdentityHostingStartup.cs
+++ b/3LTB/3LTB/Areas/Identity/IdentityHostingStartup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using _3LTB.Data;
+using _3LTB.Helpers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI;
@@ -19,7 +20,7 @@ namespace _3LTB.Areas.Identity
                     options.UseSqlServer(
                         context.Configuration.GetConnectionString("_3LTBContextConnection")));
 
-                services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
+                services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)
                     .AddEntityFrameworkStores<_3LTBContext>();
             });
         }

--- a/3LTB/3LTB/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/3LTB/3LTB/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using _3LTB.Helpers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -14,9 +15,9 @@ namespace _3LTB.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class ConfirmEmailModel : PageModel
     {
-        private readonly UserManager<IdentityUser> _userManager;
+        private readonly UserManager<ApplicationUser> _userManager;
 
-        public ConfirmEmailModel(UserManager<IdentityUser> userManager)
+        public ConfirmEmailModel(UserManager<ApplicationUser> userManager)
         {
             _userManager = userManager;
         }

--- a/3LTB/3LTB/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
+++ b/3LTB/3LTB/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
@@ -10,16 +10,17 @@ using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
+using _3LTB.Helpers;
 
 namespace _3LTB.Areas.Identity.Pages.Account
 {
     [AllowAnonymous]
     public class ForgotPasswordModel : PageModel
     {
-        private readonly UserManager<IdentityUser> _userManager;
+        private readonly UserManager<ApplicationUser> _userManager;
         private readonly IEmailSender _emailSender;
 
-        public ForgotPasswordModel(UserManager<IdentityUser> userManager, IEmailSender emailSender)
+        public ForgotPasswordModel(UserManager<ApplicationUser> userManager, IEmailSender emailSender)
         {
             _userManager = userManager;
             _emailSender = emailSender;

--- a/3LTB/3LTB/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/3LTB/3LTB/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -11,19 +11,20 @@ using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
+using _3LTB.Helpers;
 
 namespace _3LTB.Areas.Identity.Pages.Account
 {
     [AllowAnonymous]
     public class LoginModel : PageModel
     {
-        private readonly UserManager<IdentityUser> _userManager;
-        private readonly SignInManager<IdentityUser> _signInManager;
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly ILogger<LoginModel> _logger;
 
-        public LoginModel(SignInManager<IdentityUser> signInManager, 
+        public LoginModel(SignInManager<ApplicationUser> signInManager, 
             ILogger<LoginModel> logger,
-            UserManager<IdentityUser> userManager)
+            UserManager<ApplicationUser> userManager)
         {
             _userManager = userManager;
             _signInManager = signInManager;

--- a/3LTB/3LTB/Areas/Identity/Pages/Account/Logout.cshtml.cs
+++ b/3LTB/3LTB/Areas/Identity/Pages/Account/Logout.cshtml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using _3LTB.Helpers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -13,10 +14,10 @@ namespace _3LTB.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class LogoutModel : PageModel
     {
-        private readonly SignInManager<IdentityUser> _signInManager;
+        private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly ILogger<LogoutModel> _logger;
 
-        public LogoutModel(SignInManager<IdentityUser> signInManager, ILogger<LogoutModel> logger)
+        public LogoutModel(SignInManager<ApplicationUser> signInManager, ILogger<LogoutModel> logger)
         {
             _signInManager = signInManager;
             _logger = logger;

--- a/3LTB/3LTB/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/3LTB/3LTB/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using _3LTB.Helpers;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -19,14 +20,14 @@ namespace _3LTB.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class RegisterModel : PageModel
     {
-        private readonly SignInManager<IdentityUser> _signInManager;
-        private readonly UserManager<IdentityUser> _userManager;
+        private readonly SignInManager<ApplicationUser> _signInManager;
+        private readonly UserManager<ApplicationUser> _userManager;
         private readonly ILogger<RegisterModel> _logger;
         private readonly IEmailSender _emailSender;
 
         public RegisterModel(
-            UserManager<IdentityUser> userManager,
-            SignInManager<IdentityUser> signInManager,
+            UserManager<ApplicationUser> userManager,
+            SignInManager<ApplicationUser> signInManager,
             ILogger<RegisterModel> logger,
             IEmailSender emailSender)
         {
@@ -74,7 +75,7 @@ namespace _3LTB.Areas.Identity.Pages.Account
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
             if (ModelState.IsValid)
             {
-                var user = new IdentityUser { UserName = Input.Email, Email = Input.Email };
+                var user = new ApplicationUser { UserName = Input.Email, Email = Input.Email };
                 var result = await _userManager.CreateAsync(user, Input.Password);
                 if (result.Succeeded)
                 {

--- a/3LTB/3LTB/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
+++ b/3LTB/3LTB/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
@@ -6,16 +6,17 @@ using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
+using _3LTB.Helpers;
 
 namespace _3LTB.Areas.Identity.Pages.Account
 {
     [AllowAnonymous]
     public class RegisterConfirmationModel : PageModel
     {
-        private readonly UserManager<IdentityUser> _userManager;
+        private readonly UserManager<ApplicationUser> _userManager;
         private readonly IEmailSender _sender;
 
-        public RegisterConfirmationModel(UserManager<IdentityUser> userManager, IEmailSender sender)
+        public RegisterConfirmationModel(UserManager<ApplicationUser> userManager, IEmailSender sender)
         {
             _userManager = userManager;
             _sender = sender;

--- a/3LTB/3LTB/Helpers/ApplicationUser.cs
+++ b/3LTB/3LTB/Helpers/ApplicationUser.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace _3LTB.Helpers
 {
-    public class _3LTBIdentityUser : IdentityUser
+    public class ApplicationUser : IdentityUser
     {
         [ProtectedPersonalData]
         public virtual string SeniorityNumber { get; set; }

--- a/3LTB/3LTB/Views/Shared/_LoginPartial.cshtml
+++ b/3LTB/3LTB/Views/Shared/_LoginPartial.cshtml
@@ -1,7 +1,8 @@
 ﻿@using Microsoft.AspNetCore.Identity
+@using _3LTB.Helpers
 
-@inject SignInManager<IdentityUser> SignInManager
-@inject UserManager<IdentityUser> UserManager
+@inject SignInManager<ApplicationUser> SignInManager
+@inject UserManager<ApplicationUser> UserManager
 
 <ul class="navbar-nav">
 @if (SignInManager.IsSignedIn(User))


### PR DESCRIPTION
 Changed all the references affecting register/login from <IdentityUser> to <ApplicationUser>. ApplicationUser is the new name for the helper class in the Helpers subdirectory. If your AspNetUsers table already has all the new fields, there is no need to drop and recreate the db.  Just run 3LTB and create a user.